### PR TITLE
Make the first `name` argument required for all shims

### DIFF
--- a/shims.bzl
+++ b/shims.bzl
@@ -113,11 +113,13 @@ def _update_headers_with_src_headers(src_headers, out_headers):
     return out_headers
 
 def prebuilt_cpp_library(
+        name,
         headers = None,
         linker_flags = None,
         private_linker_flags = None,
         **kwargs):
     prelude.prebuilt_cxx_library(
+        name = name,
         exported_headers = headers,
         exported_linker_flags = linker_flags,
         linker_flags = private_linker_flags,
@@ -196,6 +198,7 @@ def cpp_library(
     )
 
 def cpp_unittest(
+        name,
         deps = [],
         external_deps = [],
         visibility = ["PUBLIC"],
@@ -219,6 +222,7 @@ def cpp_unittest(
         deps = deps + CPP_UNITTEST_DEPS
 
     prelude.cxx_test(
+        name = name,
         deps = _fix_deps(deps + external_deps_to_targets(external_deps)),
         visibility = visibility,
         resources = _fix_resources(resources),
@@ -226,6 +230,7 @@ def cpp_unittest(
     )
 
 def cpp_binary(
+        name,
         deps = [],
         external_deps = [],
         visibility = ["PUBLIC"],
@@ -237,12 +242,14 @@ def cpp_binary(
         **kwargs):
     _unused = (dlopen_enabled, compiler_specific_flags, os_linker_flags, allocator, modules)  # @unused
     prelude.cxx_binary(
+        name = name,
         deps = _fix_deps(deps + external_deps_to_targets(external_deps)),
         visibility = visibility,
         **kwargs
     )
 
 def rust_library(
+        name,
         edition = None,
         rustc_flags = [],
         deps = [],
@@ -266,6 +273,7 @@ def rust_library(
     visibility = ["PUBLIC"]
 
     prelude.rust_library(
+        name = name,
         edition = edition or _default_rust_edition(),
         rustc_flags = rustc_flags + [_CFG_BUCK_BUILD],
         deps = deps,
@@ -275,6 +283,7 @@ def rust_library(
     )
 
 def rust_binary(
+        name,
         edition = None,
         rustc_flags = [],
         deps = [],
@@ -289,6 +298,7 @@ def rust_binary(
 
     # @lint-ignore BUCKLINT: avoid "Direct usage of native rules is not allowed."
     prelude.rust_binary(
+        name = name,
         edition = edition or _default_rust_edition(),
         rustc_flags = rustc_flags + [_CFG_BUCK_BUILD],
         deps = deps,
@@ -297,6 +307,7 @@ def rust_binary(
     )
 
 def rust_unittest(
+        name,
         edition = None,
         rustc_flags = [],
         deps = [],
@@ -305,6 +316,7 @@ def rust_unittest(
     deps = _fix_deps(deps)
 
     prelude.rust_test(
+        name = name,
         edition = edition or _default_rust_edition(),
         rustc_flags = rustc_flags + [_CFG_BUCK_BUILD],
         deps = deps,
@@ -392,12 +404,14 @@ proto_srcs = rule(
 )
 
 def ocaml_binary(
+        name,
         deps = [],
         visibility = ["PUBLIC"],
         **kwargs):
     deps = _fix_deps(deps)
 
     prelude.ocaml_binary(
+        name = name,
         deps = deps,
         visibility = visibility,
         **kwargs


### PR DESCRIPTION
This shouldn't change any behavior, but will make failures more transparent as the user doesn't have to trace the history of the required `name` argument through (potentially) several levels of `kwargs` indirection.