### PR TITLE
feat: Add java_binary() shim

### DIFF
--- a/build_defs/java_binary.bzl
+++ b/build_defs/java_binary.bzl
@@ -1,0 +1,10 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under both the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree and the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree.
+
+load("@shim//:shims.bzl", _java_binary = "java_binary")
+
+java_binary = _java_binary

--- a/shims.bzl
+++ b/shims.bzl
@@ -254,6 +254,19 @@ def cpp_binary(
         **kwargs
     )
 
+def java_binary(
+        name,
+        jar_style = None,
+        runtime = None,
+        *args,
+        **kwargs):
+    _unused = (jar_style, runtime)  # @unused
+    return prelude.java_binary(
+        name = name,
+        *args,
+        **kwargs
+    )
+
 def rust_library(
         name,
         edition = None,


### PR DESCRIPTION
Adding a missing shim for `java_binary()`.

This may not work for the general case but it resolves an issue seen in sapling OSS.