### PR TITLE
Remove specialty handling of atomic lib in github shims

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -20,12 +20,6 @@ oncall("open_source")
 system_cxx_toolchain(
     name = "cxx",
     cxx_flags = ["-std=c++20"],
-    link_flags = select({
-        "DEFAULT": [],
-        "prelude//os:linux": [
-            "-latomic",
-        ],
-    }),
     visibility = ["PUBLIC"],
 )
 


### PR DESCRIPTION
Summary: These lines were added a year ago in D62590238 but are now the apparent cause of an error in the buck2 OSS build. We could try to work around this on the buck side, but the specialty handling of this one particular library is nonstandard anyway.

Differential Revision: D81166319


